### PR TITLE
Fix visualizer binding failure in SPA environments

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -53,6 +53,7 @@ export class PlayerElement extends HTMLElement {
   private domInitialized = false;
   private initTimeout: number;
   private needInitNs = false;
+  private pendingVisualizerSelector: string = undefined;
 
   protected player: mm.BasePlayer;
   protected controlPanel: HTMLElement;
@@ -116,6 +117,11 @@ export class PlayerElement extends HTMLElement {
     });
 
     this.initPlayerNow();
+
+    if (this.pendingVisualizerSelector !== undefined) {
+      this.setVisualizerSelector(this.pendingVisualizerSelector);
+      this.pendingVisualizerSelector = undefined;
+    }
   }
 
   attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
@@ -126,11 +132,10 @@ export class PlayerElement extends HTMLElement {
     if (name === 'sound-font' || name === 'src') {
       this.initPlayer();
     } else if (name === 'visualizer') {
-      const fn = () => { this.setVisualizerSelector(newValue); };
-      if (document.readyState === 'loading') {
-        window.addEventListener('DOMContentLoaded', fn);
+      if (this.domInitialized) {
+        this.setVisualizerSelector(newValue);
       } else {
-        fn();
+        this.pendingVisualizerSelector = newValue;
       }
     }
   }
@@ -329,7 +334,9 @@ export class PlayerElement extends HTMLElement {
 
     // Match visualizers and add them as listeners
     if (selector != null) {
-      for (const element of document.querySelectorAll(selector)) {
+      const elements = document.querySelectorAll(selector);
+      elements.forEach((el) => customElements.upgrade(el));
+      for (const element of elements) {
         if (!(element instanceof VisualizerElement)) {
           console.warn(`Selector ${selector} matched non-visualizer element`, element);
           continue;


### PR DESCRIPTION
## Bug

When `midi-player` is used in SPA frameworks (Vue, React, Svelte, etc.), the `visualizer` attribute binding silently fails if the selector depends on DOM hierarchy (e.g. `#container midi-visualizer`).

### Root cause

Per the Custom Elements spec, `attributeChangedCallback` fires before `connectedCallback`. In static HTML this is handled by checking `document.readyState === 'loading'` and deferring to `DOMContentLoaded`. However, in SPA environments `readyState` is already `'interactive'` or `'complete'`, so `setVisualizerSelector` is called immediately — before the element is inserted into the DOM. `document.querySelectorAll` with a hierarchical selector returns no results, and the visualizer is never bound.

### Minimal reproduction

```html
<!-- Vue SPA component -->
<script setup>
import "html-midi-player";
</script>

<template>
  <div id="container">
    <midi-visualizer type="piano-roll" src="/test.mid" />
    <midi-player src="/test.mid" sound-font visualizer="#container midi-visualizer" />
  </div>
</template>
```

**Expected**: Notes highlight with `active` class during playback.  
**Actual**: No notes are highlighted. No errors or warnings in console.

### Note

Using a simple tag selector like `visualizer="midi-visualizer"` works as a workaround since it doesn't depend on DOM hierarchy, but hierarchical selectors are needed when multiple visualizers exist on the page.

## Fix

1. When `attributeChangedCallback` fires before `connectedCallback` (`domInitialized === false`), store the selector and defer `setVisualizerSelector` to `connectedCallback`, when sibling elements are guaranteed to be in the DOM.
2. Call `customElements.upgrade()` on matched elements in `setVisualizerSelector` to ensure they are upgraded before the `instanceof VisualizerElement` check.